### PR TITLE
output ut alpha in upper triangular format

### DIFF
--- a/loprop.py
+++ b/loprop.py
@@ -1356,6 +1356,7 @@ class MolFrag:
                         if pol == 1: 
                             line += fmt % (Asym.trace()/3*xconv3)
                         elif pol %10 == 2: 
+                            Asym[2:4] = Asym[3:1:-1]
                             line += (6*fmt) % tuple(Asym.pack().view(full.matrix)*xconv3)
 
                 if hyper > 0:


### PR DESCRIPTION
Change from MOLCAS lower triangular to DALTON upper for POT files if  alpha > 1

All tests are fine.
