### PR TITLE
Proposal: Make it easier to install LoProp as dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
+*egg*
 build
+dist
+
 
 *.pyc
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+build
+
 *.pyc
 *.swp
 venv

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ virtualenv:
    system_site_packages: true
 before_install:
    - sudo apt-get update -qq
-   - install -qq python-numpy python-scipy
+   - sudo apt-get install python-numpy python-scipy
    - git submodule update --init --recursive
 
 script: nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 language: python
+
+sudo: true
+
 python:
    - "2.7"
+
 virtualenv:
    system_site_packages: true
+
 before_install:
-     #- sudo apt-get update -qq
-     #- sudo apt-get install python-numpy python-scipy
+   - sudo apt-get update -qq
+   - sudo apt-get install python-numpy python-scipy
    - git submodule update --init --recursive
 
 script: nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ virtualenv:
 
 before_install:
    - sudo apt-get update -qq
-   - sudo apt-get install python-numpy libblas-dev liblapack-dev
+   - sudo apt-get install python-numpy libblas-dev liblapack-dev libatlas-base-dev gfortran
    - git submodule update --init --recursive
 
 install: pip install --use-wheel -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,6 @@ before_install:
    - sudo apt-get install python-numpy python-scipy
    - git submodule update --init --recursive
 
+install: pip install --use-wheel -r requirements.txt
+
 script: nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ virtualenv:
 
 before_install:
    - sudo apt-get update -qq
-   - sudo apt-get install python-numpy python-scipy
+   - sudo apt-get install python-numpy
    - git submodule update --init --recursive
 
 install: pip install --use-wheel -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ virtualenv:
    system_site_packages: true
 
 before_install:
-   #- sudo apt-get update -qq
-   #- sudo apt-get install python-numpy libblas-dev liblapack-dev libatlas-base-dev gfortran
+   - sudo apt-get update -qq
+   - sudo apt-get install libblas-dev liblapack-dev libatlas-base-dev gfortran
    - git submodule update --init --recursive
 
 install: python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ virtualenv:
 
 before_install:
    - sudo apt-get update -qq
-   - sudo apt-get install python-numpy
+   - sudo apt-get install python-numpy libblas-dev liblapack-dev
    - git submodule update --init --recursive
 
 install: pip install --use-wheel -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ python:
 virtualenv:
    system_site_packages: true
 before_install:
-   - "sudo apt-get install -qq python-numpy python-scipy"
-install: 
-   - "git submodule update --init --recursive"
+   - sudo apt-get update -qq
+   - install -qq python-numpy python-scipy
+   - git submodule update --init --recursive
+
 script: nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
 virtualenv:
    system_site_packages: true
 before_install:
-   - sudo apt-get update -qq
-   - sudo apt-get install python-numpy python-scipy
+     #- sudo apt-get update -qq
+     #- sudo apt-get install python-numpy python-scipy
    - git submodule update --init --recursive
 
 script: nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ virtualenv:
    system_site_packages: true
 
 before_install:
-   - sudo apt-get update -qq
-   - sudo apt-get install python-numpy libblas-dev liblapack-dev libatlas-base-dev gfortran
+   #- sudo apt-get update -qq
+   #- sudo apt-get install python-numpy libblas-dev liblapack-dev libatlas-base-dev gfortran
    - git submodule update --init --recursive
 
-install: pip install --use-wheel -r requirements.txt
+install: python setup.py install
 
 script: nosetests

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,18 @@
 #!/usr/bin/env python
-from distutils.core import setup
+
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+import os
+
+#if submodules have not been initiated, just update them
+os.system( 'git submodule update --init --recursive' )
+
+reqs = ['argparse>=1.2.1',
+        'numpy>=1.9.2',
+        'scipy>=0.16.0',
+        'wsgiref>=0.1.2' ]
 
 setup(name="LoProp",
     version="0.1",
@@ -7,6 +20,5 @@ setup(name="LoProp",
     scripts=["loprop.py",],
     author="Olav Vahtras",
     author_email="vahtras@kth.se",
+    install_requires = reqs,
     )
-
-    


### PR DESCRIPTION
This way its possible to run a simple python setup.py install and it will grab all deps.

Furthermore, it is easy to just point to this repo from other repos via setup.py, as it is not in the pypi and has submodule dependencies.
