### PR TITLE
Proposal: Make it easier to install LoProp as dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *.pyc
 *.swp
 venv
+
+dist
+build
+*egg*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,18 @@
 language: python
+
+sudo: true
+
 python:
    - "2.7"
+
 virtualenv:
    system_site_packages: true
+
 before_install:
-   - "sudo apt-get install -qq python-numpy python-scipy"
-install: 
-   - "git submodule update --init --recursive"
+   - sudo apt-get update -qq
+   - sudo apt-get install libblas-dev liblapack-dev libatlas-base-dev gfortran
+   - git submodule update --init --recursive
+
+install: python setup.py install
+
 script: nosetests

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,18 @@
 #!/usr/bin/env python
-from distutils.core import setup
+
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+import os
+
+#if submodules have not been initiated, just update them
+os.system( 'git submodule update --init --recursive' )
+
+reqs = ['argparse>=1.2.1',
+        'numpy>=1.9.2',
+        'scipy>=0.16.0',
+        'wsgiref>=0.1.2' ]
 
 setup(name="LoProp",
     version="0.1",
@@ -7,6 +20,5 @@ setup(name="LoProp",
     scripts=["loprop.py",],
     author="Olav Vahtras",
     author_email="vahtras@kth.se",
+    install_requires = reqs,
     )
-
-    


### PR DESCRIPTION
new installation scheme via python setup.py install, makes it easier to manage loprop with other pip installable python packages, as loprop does not exit in pypi and has submodule dependencies.
