### PR TITLE
Check against more types in core.py

### DIFF
--- a/loprop/core.py
+++ b/loprop/core.py
@@ -169,12 +169,12 @@ class LoPropTransformer:
     @staticmethod
     def assert_pos_ints(arr):
         for a in arr:
-            assert type(a) == int and a > 0
+            assert isinstance(a, (int, numpy.intc, numpy.int32, numpy.int64)) and a > 0
 
     @staticmethod
     def assert_nonneg_ints(arr):
         for a in arr:
-            assert type(a) in [int, numpy.int64] and a >= 0
+            assert isinstance(a, (int, numpy.intc, numpy.int32, numpy.int64)) and a >= 0
 
     @property
     def T(self):


### PR DESCRIPTION
Fixes an issue encountered on Windows. I guess it would be more robust to cast to `int` and just check that the elements are (strictly) positive, but this suffices for my use case at the moment. Would you mint a new release when this gets merged?